### PR TITLE
fix(workflows/deploy) replace `shalzz/zola-deploy-action` with `zolacti/on`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,8 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Build only
         uses: zolacti/on@main
         with:
@@ -21,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Build and deploy
         uses: zolacti/on@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,4 @@
-name: Zola on GitHub Pages
-
+name: Deploy Zola to GH Pages
 on:
   push:
     branches:
@@ -11,25 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
+      # - name: Checkout
+      #   uses: actions/checkout@v3
       - name: Build only
-        uses: shalzz/zola-deploy-action@v0.20.0
-        env:
-          BUILD_ONLY: true
-          BUILD_FLAGS: --drafts
-          CHECK_LINKS: true
+        uses: zolacti/on@main
+        with:
+          deploy: false
 
-  build-and-deploy:
+  build_and_deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
+      # - name: Checkout
+      #   uses: actions/checkout@v3
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@v0.20.0
-        env:
-          CHECK_LINKS: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OUT_DIR: docs
-          PAGES_BRANCH: gh-pages
+        uses: zolacti/on@main


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace `shalzz/zola-deploy-action` with `zolacti/on` in the GitHub Actions workflow for deploying Zola to GitHub Pages.