### PR TITLE
refactor: update base URL in Zola builds to `www.ruancomelli.com`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           deploy: false
 
-  build_and_deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://ruancomelli.github.io/"
+base_url = "https://www.ruancomelli.com/"
 author = "Ruan Comelli"
 
 theme = "linkita"


### PR DESCRIPTION
## Summary by Sourcery

Updates the base URL in Zola builds from `ruancomelli.github.io` to `www.ruancomelli.com` and corrects a typo in the CI workflow name.

Build:
- Updates the base URL in the Zola configuration to the new domain.

CI:
- Fixes a typo in the CI workflow name, changing `build_and_deploy` to `build-and-deploy`.