### PR TITLE
ci: skip checking LinkedIn profile URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,12 @@ highlight_code = true
 extra_syntaxes_and_themes = []
 highlight_theme = "dracula"
 
+[link_checker]
+skip_prefixes = [
+	# I don't know why, but my LinkedIn profile URL is flagged as invalid
+	"https://www.linkedin.com/in/ruancomelli/",
+]
+
 [extra]
 math = true
 mermaid = true


### PR DESCRIPTION
For some reason known only to the gods of webdev, my LinkedIn profile URL is reported as invalid by `zola check`.
This is just a workaround to avoid having that error stop the build workflow.

## Summary by Sourcery

CI:
- Add configuration to skip checking a specific LinkedIn profile URL in the link validation process