### PR TITLE
feat: add a link to the website source

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -53,6 +53,7 @@ disable_default_favicon = false
 since = 2025
 license_url = "https://creativecommons.org/licenses/by-sa/4.0/"
 copyright = "&copy; $YEAR Ruan Comelli &vert; [CC BY-SA 4.0]($LICENSE_URL)"
+site_repository = "https://github.com/ruancomelli/ruancomelli.github.io"
 
 [extra.giscus]
 repo = "ruancomelli/ruancomelli"

--- a/templates/injects/footer.html
+++ b/templates/injects/footer.html
@@ -1,0 +1,22 @@
+<!--
+A footer partial that gets injected into the footer.
+Check themes/linkita/templates/partials/footer.html.
+-->
+
+{%- if config.extra.footer.site_repository %}
+<div class="flex justify-center mt-4">
+  <a
+    class="link flex items-center gap-2"
+    href="{{ config.extra.footer.site_repository }}"
+    target="_blank"
+    title="View source code"
+  >
+    <img
+      class="inline-block h-4 w-4 dark:invert"
+      src="icons/github.svg"
+      alt="GitHub"
+    />
+    <span>Open on GitHub</span>
+  </a>
+</div>
+{%- endif %}


### PR DESCRIPTION
## Summary by Sourcery

Add a link to the website's source repository in the footer

New Features:
- Add a GitHub link in the website footer that points to the site's source repository

Enhancements:
- Modify site configuration to include the repository URL for the website

Documentation:
- Create a new footer template that conditionally displays a link to the site's source code