### PR TITLE
chore: attempt to fix Mobile rendering by disabling CDN

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,6 @@ mermaid = true
 comment = true
 title_separator = " | "
 header_menu_name = "sample_header"
-use_cdn = true
 disable_default_favicon = false
 
 [extra.footer]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove CDN configuration from the site's configuration file